### PR TITLE
Changed VS code installation commands.

### DIFF
--- a/scripts/post_script.sh
+++ b/scripts/post_script.sh
@@ -41,9 +41,10 @@ rosdep init
 rosdep update
 
 # Install VS Code
-cd /tmp
-curl -o code.deb -L http://go.microsoft.com/fwlink/?LinkID=760868
-apt-get install -y ./code.deb
+apt-get update
+wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /usr/share/keyrings/microsoft.gpg > /dev/null
+sh -c 'echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/code stable main" > /etc/apt/sources.list.d/vscode.list'
+apt-get update && apt-get install -y code
 
 # Let's have a custom PS1 to help people realise in which container they are
 # working.


### PR DESCRIPTION
Changed commands in post script for how to install VS code. Previous version now required a prompt by the user, which is not possible in VS code.